### PR TITLE
feat: add cage config

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,0 +1,2 @@
+reviews:
+  language: ja

--- a/cage/presets.yaml
+++ b/cage/presets.yaml
@@ -1,0 +1,34 @@
+presets:
+  base:
+    allow:
+      - "." # current
+      - "$XDG_CACHE_HOME" # ~/.cache
+      - "$XDG_DATA_HOME" # ~/.local/share
+      - "/tmp" # linux tmp directory
+      - "/private/tmp" # macos tmp directory
+      - "/var/folders" # macos mktemp
+      - "/Library/Caches" # macos app caches
+      - "$HOME/Library/Caches" # macos app caches
+
+  git-enabled:
+    allow-git: true
+    allow-keychain: true # macOS only
+
+  claude-code:
+    allow:
+      - "$CLAUDE_CONFIG_DIR"
+      - "$HOME/.serena"
+      - ".serena"
+      - "/dev/tty"
+      - "$HOME/.claude"
+      - "$HOME/.claude.json"
+      - "$HOME/.claude.json.backup"
+      - "$HOME/.claude.json.lock"
+      - "$HOME/.claude.lock"
+
+auto-presets:
+  - command: claude
+    presets:
+      - base
+      - git-enabled
+      - claude-code

--- a/symlink.sh
+++ b/symlink.sh
@@ -21,7 +21,10 @@ done
 
 # cage
 if [[ "$(uname -s)" == "Darwin" ]]; then
-  ln -s $homedir/cage $HOME/Library/Application\ Support/cage
+  cagedir="$HOME/Library/Application Support/cage"
 elif [[ "$(uname -s)" == "Linux" ]]; then
-  ln -s $homedir/cage $HOME/.config/cage
+  cagedir="$HOME/.config/cage"
+fi
+if [ ! -L "$cagedir" ]; then
+  ln -s "$homedir/cage" "$cagedir"
 fi

--- a/symlink.sh
+++ b/symlink.sh
@@ -18,3 +18,10 @@ for file in ${dotfilelist[@]}; do
     ln -s $src $dist
   fi
 done
+
+# cage
+if [[ "$(uname -s)" == "Darwin" ]]; then
+  ln -s $homedir/cage $HOME/Library/Application\ Support/cage
+elif [[ "$(uname -s)" == "Linux" ]]; then
+  ln -s $homedir/cage $HOME/.config/cage
+fi


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced reusable configuration presets for cage environments with preset composition support
  * Enabled automatic preset application when running the claude command
  * Added platform-specific setup for configuration paths on macOS and Linux
  * Set default review language to Japanese for automated reviews
<!-- end of auto-generated comment: release notes by coderabbit.ai -->