### PR TITLE
feat(cage): add maven and go presets to allow home directory access

### DIFF
--- a/cage/presets.yaml
+++ b/cage/presets.yaml
@@ -26,9 +26,19 @@ presets:
       - "$HOME/.claude.json.lock"
       - "$HOME/.claude.lock"
 
+  maven:
+    allow:
+      - "$HOME/.m2"
+
+  go:
+    allow:
+      - "$HOME/go"
+
 auto-presets:
   - command: claude
     presets:
       - base
       - git-enabled
       - claude-code
+      - maven
+      - go

--- a/cage/presets.yaml
+++ b/cage/presets.yaml
@@ -28,11 +28,13 @@ presets:
 
   maven:
     allow:
-      - "$HOME/.m2"
+      - "$HOME/.m2/repository"
+      - "$HOME/.m2/wrapper"
 
   go:
     allow:
-      - "$HOME/go"
+      - "$HOME/go/pkg/mod"
+      - "$HOME/go/bin"
 
 auto-presets:
   - command: claude


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Maven 用プリセットと Go 用プリセットを追加しました。
  * Maven のローカルキャッシュディレクトリおよび Go のモジュール/バイナリディレクトリへのファイルアクセスが許可されます。
  * これらのプリセットは Claude コマンド実行時に自動で適用され、関連作業の利便性が向上します。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->